### PR TITLE
add another option *styleMode*

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ class HTMLStream extends Transform {
     this.neck = template.neck
     this.tail = template.tail
     this.context = options.context || {}
+    this.styleMode = options.styleMode == null || options.styleMode
   }
 
   _transform (data, encoding, done) {
@@ -22,7 +23,7 @@ class HTMLStream extends Transform {
         this.push(this.context.head)
       }
       // inline server-rendered CSS collected by vue-style-loader
-      if (this.context.styles) {
+      if (this.styleMode && this.context.styles) {
         this.push(this.context.styles)
       }
       this.push(this.neck)
@@ -38,6 +39,9 @@ class HTMLStream extends Transform {
       this.push(`<script>window.__INITIAL_STATE__=${
         serialize(this.context.state, { isJSON: true })
       }</script>`)
+    }
+    if (!this.styleMode && this.context.styles) {
+      this.push(this.context.styles)
     }
     this.push(this.tail)
     done()


### PR DESCRIPTION
When we are running on development, usually we won't extract global styles to a *.css* file, what will make the global style loaded after the server rendered *style* tags, then the style could be overridden by global styles.

By default, `styleMode` is `true`, if it is set to `false`, the server rendered *styles* tags will be injected before `tail` instead of after `head`, so that the server rendered styles won't be overridden by global styles.